### PR TITLE
Center content in middle column

### DIFF
--- a/openff_sphinx_theme/openff_sphinx_theme/sass/admonitions.sass
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/admonitions.sass
@@ -124,9 +124,6 @@
       page-break-inside: avoid
       border-left: 0.25rem solid $accent
       border-radius: 0.125rem
-      width: fit-content
-      max-width: 100%
-      min-width: $para-width
       @include z-depth(2)
 
       // [print]: Omit shadow as it may lead to rendering errors

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
@@ -82,6 +82,8 @@ $bulma-admonitions: false
 $admonition-margin: 1.25rem
 
 $para-width: 80ex
+$widescreen-expandable-width: 57vw
+$fullhd-expandable-width: 95ex
 
 // @import "bulma/bulma.sass"
 // Important that we exclude the .section class, as it clashes with Sphinx 4+
@@ -113,6 +115,21 @@ $breadcrumb-item-separator-color-light: findColorInvert($breadcrumb-item-separat
     &::-webkit-scrollbar
         display: none
 
+// For elements like code blocks and API references where we want them to take up a bit more space on
+// larger screens
+@mixin expandable
+  @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1)
+    margin-left: calc(-1 * (#{$widescreen-expandable-width} - #{$para-width}) / 2) !important
+    width: $widescreen-expandable-width !important
+  @media screen and (min-width: $fullhd)
+    margin-left: calc(-1 * (#{$fullhd-expandable-width} - #{$para-width}) / 2) !important
+    width: $fullhd-expandable-width !important
+  // Unexpand any nested expandables
+  @media screen and (min-width: $widescreen)
+    .highlight, .math, dl:not(.docutils):not(.field-list):not(.simple):not(.citation):not(.option-list):not(.footnote)[class]
+        width: 100% !important
+        margin-left: 0 !important
+
 // Offset scrolling by the height of the fixed header
 html
     scroll-padding-top: $navbar-height + $below-navbar-spacing
@@ -126,11 +143,17 @@ html
     line-height: 1.6
     color-adjust: exact
     @media screen and (max-width: $tablet - 1px)
-      width: 100vw - 2 * $mobile-content-margin-y
-      margin-left: $mobile-content-margin-y
-      margin-right: $mobile-content-margin-y
+        width: 100vw - 2 * $mobile-content-margin-y
+        margin-left: $mobile-content-margin-y
+        margin-right: $mobile-content-margin-y
     @media screen and (min-width: $tablet) and (max-width: $desktop - 1px)
-      margin-left: $mobile-content-margin-y
+        margin-left: $mobile-content-margin-y
+    @media screen and (min-width: $desktop)
+        > *
+            margin-left: auto
+            margin-right: auto
+            max-width: $para-width
+
 
 
 header, .navbar.is-primary.has-shadow

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-api.scss
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-api.scss
@@ -21,6 +21,7 @@ $api-arguments-indent: 2 * $api-header-font-size;
 // RTD does it like this, but with fewer exceptions, so
 // we should be OK
 dl:not(.docutils):not(.field-list):not(.simple):not(.citation):not(.option-list):not(.footnote)[class] {
+    @include expandable;
     // Header and signature
     > dt {
         font-family: $family-monospace;

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-content.scss
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-content.scss
@@ -124,12 +124,7 @@ table.highlighttable {
     overflow-x: unset;
     margin: unset;
   }
-  // Neat but expandable code blocks;
-  @media screen and (min-width: $desktop) {
-    width: fit-content;
-    max-width: 100%;
-    min-width: $para-width;
-  }
+  @include expandable;
   /// Code with line numbers in sphinx>=4
   span.linenos {
     margin-right: 1.5rem;
@@ -141,12 +136,8 @@ table.highlighttable {
 }
 
 // Neat but expandable maths;
-.math {
-  @media screen and (min-width: $desktop) {
-    width: fit-content;
-    max-width: 100%;
-    min-width: $para-width;
-  }
+div.math {
+  @include expandable;
 }
 
 // Header links
@@ -177,14 +168,6 @@ table.highlighttable {
 // Don't let Sphinx try to be clever about what header level the index heading is
 #index h3 {
   @extend h2;
-}
-
-// Prose paragraphs should wrap at around 80 characters
-// The visual artifact is almost unnoticeable and the
-// improved ease of reading is enormous,
-// and theres no issues with having to condense API stuff
-p:not(.admonition-title) {
-  max-width: $para-width;
 }
 
 // Use Bulma's tables
@@ -332,6 +315,7 @@ a.brackets {
   .highlight {
     width: 100%;
   }
+  @include expandable;
 }
 
 .nbinput {
@@ -372,6 +356,7 @@ a.brackets {
 // MyST-nb notebooks
 
 .cell.container {
+  @include expandable;
   border: none;
   @include z-depth(2);
   >.cell_input {


### PR DESCRIPTION
This is an alternative to #35. It centers things, but also allows certain elements (API references, code blocks, maths blocks) to expand slightly on large screens (while remaining centered). Fixes #32 and fixes #33.

![Screenshot from 2022-02-16 16-15-45](https://user-images.githubusercontent.com/28590748/154200889-ccab4be4-529b-4e6b-8469-ceafbbf5a31c.png)

Ideally, I'd like this expansion only to happen when the code block is too wide for the 80ex column, but the HTML structure outputted by sphinx makes this impossible without either (a) enumerating every possible code block class in CSS (`.highlight-py, .highlight-python, .highlight-python3, .highlight-sh, .highlight-shell, .highlight-shell-session` etc) or (b) allowing anything that is `div.notranslate` to expand to fit its content.

@SimonBoothroyd, what do you think of this solution? Thanks for your feedback!