### PR TITLE
Refinements to layout

### DIFF
--- a/openff_sphinx_theme/openff_sphinx_theme/header.html
+++ b/openff_sphinx_theme/openff_sphinx_theme/header.html
@@ -44,7 +44,7 @@
         >
       </a>
     </div>
-    <span class="navbar-burger-spacer is-hidden-desktop"></span>
+    <span class="navbar-burger-spacer is-hidden-tablet"></span>
   </nav>
 
   {% include "hero.html" %}

--- a/openff_sphinx_theme/openff_sphinx_theme/layout.html
+++ b/openff_sphinx_theme/openff_sphinx_theme/layout.html
@@ -54,15 +54,15 @@
   <main class="mb-6">
       <div class="columns">
         <input type="checkbox" id="drawer-toggle" class="is-hidden">
-        <label for="drawer-toggle" role="button" class="navbar-burger burger is-light">
+        <label for="drawer-toggle" role="button" class="navbar-burger burger is-light is-hidden-tablet">
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
         </label>
 
-        <aside class="column is-2" id="drawer">
-          <div class="is-hidden-tablet">
+        <aside class="column is-2-desktop is-3-tablet" id="drawer">
+          <div class="is-hidden-tablet clip-siblings">
             <a href="{{ pathto(master_doc)|e }}" title="{{ docstitle|e }}">
               <h1>
                 {{ shorttitle|striptags|e }}
@@ -81,7 +81,7 @@
           </article>
         </div>
 
-        <aside class="column is-hidden-mobile is-2-desktop is-3-tablet">
+        <aside class="column is-hidden-touch is-2">
           {% include "localtoc.html" %}
         </aside>
       </div>

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
@@ -293,17 +293,24 @@ header
         $search-animation-cutoff: $widescreen
         @media screen and (max-width: $search-animation-cutoff - 1px)
             .control
+                position: relative
+                height: $input-height
                 input
                     background-color: unset
                     width: $input-height
+                    position: absolute
+                    right: 0
                     &:hover, &:focus, &:active
                         width: 15rem
+                        max-width: 15rem
                     &:hover
                         background-color: darken($primary, 10)
+                        color: $white
                         &::placeholder
                             color: $input-icon-color
                     &:focus, &:active
                         background-color: $white
+                        color: darken($primary, 10)
                         &::placeholder
                             color: $input-placeholder-color
                 &.has-icons-right
@@ -313,10 +320,12 @@ header
         @media screen and (min-width: $search-animation-cutoff)
             input
                 background-color: darken($primary, 10)
+                color: $white
                 &::placeholder
                     color: $input-icon-color
                 &:hover, &:focus, &:active
                     background-color: $white
+                    color: darken($primary, 10)
                     &::placeholder
                         color: $input-placeholder-color
 

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
@@ -66,6 +66,7 @@ $menu-item-active-color: findColorInvert($link-active)
 $menu-item-hover-color: $link-hover
 $background: #FFFFFF
 $body-background-color: $background
+$menu-item-hover-background-color: transparent
 
 $footer-background-color: darken($primary, 12)
 
@@ -158,7 +159,7 @@ header, .navbar.is-primary.has-shadow
 $drawer-width: 20rem
 $drawer-transition-time: 0.5s
 
-@media screen and (max-width: $desktop - 1px)
+@media screen and (max-width: $tablet - 1px)
     .burger
         position: fixed
         top: 0
@@ -205,7 +206,6 @@ $drawer-transition-time: 0.5s
         position: fixed
         display: block
         z-index: 12
-        overflow-y: scroll
         .ff-globaltoc
             position: unset
 
@@ -227,12 +227,17 @@ $drawer-transition-time: 0.5s
         & + li::before
             color: $breadcrumb-item-separator-color-light
 
+// Style to have this element cover any siblings
+.clip-siblings
+    background: $background
+    position: relative
+
 .ff-localtoc, .ff-globaltoc
     position: sticky
     padding: $below-navbar-spacing
     overflow-y: auto
     // Don't know why this is necessary, probably because of drawer shenanigans?
-    @media screen and (max-width: $desktop)
+    @media screen and (max-width: $tablet)
         position: fixed
         top: $navbar-height
     // We can put visible scrollbars on the sidebars, at the

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-api.scss
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-api.scss
@@ -336,17 +336,6 @@ dl:not(.docutils):not(.field-list):not(.simple):not(.citation):not(.option-list)
             }
         }
     }
-
-    // Undo margin hackery for code blocks in API defs
-    .highlight {
-        @media screen and (min-width: $widescreen) {
-            margin-left: 0;
-            width: 100%;
-            &::before {
-                right: 0.25rem;
-            }
-        }
-    }
 }
 
 // Pydantic fields have their own stuff going on

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-content.scss
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-content.scss
@@ -146,6 +146,15 @@ table.highlighttable {
     }
   }
 }
+// Undo margin hackery for blockquotes
+blockquote .highlight {
+  margin-left: 0;
+  width: unset;
+  &::before {
+    right: 0.25rem !important;
+  }
+}
+
 
 .table-container.autosummary {
   table {

--- a/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-content.scss
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/sphinx-content.scss
@@ -128,15 +128,6 @@ table.highlighttable {
     overflow-x: unset;
     margin: unset;
   }
-  // Give ourselves some more room on big screens
-  @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1) {
-      margin-left: calc(-0.5 * (#{$code-widescreen-width} - #{$para-width}));
-      width: $code-widescreen-width;
-  }
-  @media screen and (min-width: $fullhd) {
-      margin-left: -0.5 * ($code-fullhd-width - $para-width);
-      width: $code-fullhd-width;
-  }
   /// Code with line numbers in sphinx>=4
   span.linenos {
     margin-right: 1.5rem;
@@ -146,12 +137,24 @@ table.highlighttable {
     }
   }
 }
-// Undo margin hackery for blockquotes
-blockquote .highlight {
-  margin-left: 0;
-  width: unset;
+
+// Give ourselves some more room on top-level code blocks and big screens
+.section > .notranslate > .highlight {
+  @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1) {
+      margin-left: calc(-0.5 * (#{$code-widescreen-width} - #{$para-width}));
+      width: $code-widescreen-width;
+  }
+  @media screen and (min-width: $fullhd) {
+      margin-left: -0.5 * ($code-fullhd-width - $para-width);
+      width: $code-fullhd-width;
+  }
   &::before {
-    right: 0.25rem !important;
+    @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1) {
+      right: calc(0.25rem - 0.5 * (#{$code-widescreen-width} - #{$para-width}));
+    }
+    @media screen and (min-width: $fullhd) {
+      right: calc(0.25rem - 0.5 * (#{$code-fullhd-width} - #{$para-width}));
+    }
   }
 }
 
@@ -214,16 +217,6 @@ blockquote .highlight {
           background-color: rgba(0, 0, 0, 0.035);
         }
       }
-    }
-  }
-}
-
-table {
-  // Undo margin hackery for code blocks in tables
-  .highlight {
-    @media screen and (min-width: $widescreen) {
-      margin-left: 0;
-      width: 100%;
     }
   }
 }
@@ -324,15 +317,7 @@ a.brackets {
     font-variant: small-caps;
     position: absolute;
     z-index: 10;
-    @media screen and (max-width: $widescreen - 1) {
-      right: 0.25rem;
-    }
-    @media screen and (min-width: $widescreen) and (max-width: $fullhd - 1) {
-      right: calc(0.25rem - 0.5 * (#{$code-widescreen-width} - #{$para-width}));
-    }
-    @media screen and (min-width: $fullhd) {
-      right: calc(0.25rem - 0.5 * (#{$code-fullhd-width} - #{$para-width}));
-    }
+    right: 0.25rem;
   }
 }
 
@@ -504,12 +489,7 @@ a.brackets {
     }
   }
 
-  // Undo margin hackery for myst notebooks
   .highlight {
       border: none;
-      @media screen and (min-width: $widescreen) {
-          margin-left: 0;
-          width: 100%;
-      }
   }
 }


### PR DESCRIPTION
- Globaltoc on left for tablet-sized screens instead of localtoc on right
- Expanding search bar on tablet-sized screens renders over title
- Fix input text colours in search bar when not focussed
- Simplify expanding code blocks so they only appear on top-level code blocks, rather than needing exceptions everywhere else