### PR TITLE
Fix inconsistent and confusing globaltoc layout

### DIFF
--- a/docs/additional_samples.rst
+++ b/docs/additional_samples.rst
@@ -7,16 +7,6 @@ Various examples of styling applied to Sphinx constructs. You can
 view the `source <./_sources/examples.txt>`_ of this page to see the specific
 reStructuredText used to create these examples.
 
-Subpages
-========
-
-Suppages get bread crumbs when they are not at the top level.
-
-.. toctree::
-
-    subpage/index
-
-
 
 Headings
 ========

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ html_show_sourcelink = True
 html_sidebars = {
     "**": ["globaltoc.html", "localtoc.html", "searchbox.html"],
     "customization": ["globaltoc.html", "searchbox.html"],
+    "subpage/second-subsubpage": ["globaltoc.html", "searchbox.html"],
 }
 
 # material theme options (see theme.conf for more information)
@@ -106,7 +107,7 @@ html_theme_options = {
     "repo_name": "openff-sphinx-theme",
     "html_minify": False,
     "css_minify": False,
-    "globaltoc_depth": 2,
+    "globaltoc_depth": 3,
     "globaltoc_include_local": True,
     "color_accent": "openff-toolkit-blue",
     "html_hyphenate_and_justify": True,

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,4 +21,6 @@ dependencies:
   - myst-nb
   - pandoc
   - wheel
+  - sphinx-autobuild
+  - sphinx >=4.5,<5
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,7 @@ or ``theme.conf`` for more details.
     customization
     specimen
     additional_samples
+    subpage/index
 
 
 .. toctree::

--- a/docs/subpage/index.rst
+++ b/docs/subpage/index.rst
@@ -10,3 +10,13 @@ Stepping lower into the hierarchy changes the tab par along the top.
 
    subsubpage
    second-subsubpage
+
+
+Heading 1
+=========
+
+Heading 2
+=========
+
+Heading 3
+=========

--- a/docs/subpage/second-subsubpage.rst
+++ b/docs/subpage/second-subsubpage.rst
@@ -21,3 +21,23 @@ lobortis feugiat vivamus at augue. Mollis aliquam ut porttitor leo a diam
 sollicitudin tempor id. Ipsum faucibus vitae aliquet nec. Eu sem integer vitae
 justo eget magna fermentum iaculis. Adipiscing commodo elit at imperdiet dui
 accumsan sit amet nulla.
+
+Subheading A
+------------
+
+This page has localtoc on the left.
+
+Subheading B
+------------
+
+Subsubheading
+.............
+
+Subheading C
+------------
+
+Second title of second subpage
+==============================
+
+Second title subheading
+-----------------------

--- a/docs/subpage/subsubpage.rst
+++ b/docs/subpage/subsubpage.rst
@@ -21,3 +21,6 @@ lobortis feugiat vivamus at augue. Mollis aliquam ut porttitor leo a diam
 sollicitudin tempor id. Ipsum faucibus vitae aliquet nec. Eu sem integer vitae
 justo eget magna fermentum iaculis. Adipiscing commodo elit at imperdiet dui
 accumsan sit amet nulla.
+
+Bonus subsubpage heading
+------------------------

--- a/openff_sphinx_theme/openff_sphinx_theme/globaltoc.html
+++ b/openff_sphinx_theme/openff_sphinx_theme/globaltoc.html
@@ -1,65 +1,39 @@
-{% set toctree = toctree(maxdepth=theme_globaltoc_depth|toint, collapse=theme_globaltoc_collapse|tobool, includehidden=theme_globaltoc_includehidden|tobool) %}
+{% set toctree = toctree(maxdepth=theme_globaltoc_depth|toint, collapse=True, includehidden=theme_globaltoc_includehidden|tobool, titles_only=True) %}
 {% if toctree and (sidebars is not defined or 'globaltoc.html' in sidebars) %}
-<nav class="menu ff-globaltoc">
-  {% set toctree_nodes = derender_toc(toctree, False) %}
-  {%- for item in toctree_nodes %}
-    {% if "caption" in item %}
-      {% if not loop.first %}
-        </ul>
+  {%- set toctree_nodes = derender_toc(toctree, False) -%}
+  {%- if toc -%}
+    {%- set localtoc_nodes = derender_toc(toc, False) -%}
+  {%- endif -%}
+  <nav class="menu ff-globaltoc">
+    {%- for item in toctree_nodes recursive %}
+      {%- if loop.depth0<theme_globaltoc_depth|toint -%}
+        {% if "caption" in item %}
+          {% if not loop.first %}
+            </ul>
+          {% endif %}
+          <p class="menu-label">{{ item.caption }}</p>
+          <ul class="menu-list">
+        {% else %}
+          {% if loop.first %}
+            <ul class="menu-list">
+          {% endif %}
+          <li>
+            <a href="{{ item.href|e }}" class="{% if item.current %}is-active{% endif %}">{{ item.contents }}</a>
+            {{ loop(item.children) }}
+            {# Inject localtoc if configured #}
+            {%- if theme_globaltoc_include_local and 'localtoc.html' not in sidebars -%}
+                {%- set outerloop = loop %}
+                {%- for node in localtoc_nodes if node.href == item.href and node.contents == item.contents -%}
+                  {{ outerloop(node.children) }}
+                {%- endfor -%}
+            {%- endif -%}
+          </li>
+          {% if loop.last %}
+            </ul>
+          {% endif %}
+        {% endif %}
       {% endif %}
-      <p class="menu-label">{{ item.caption }}</p>
-      <ul class="menu-list">
-    {% else %}
-      {% if loop.first %}
-        <ul class="menu-list">
-      {% endif %}
-      <li>
-        <a href="{{ item.href|e }}" class="{% if item.current %}is-active{% endif %}">{{ item.contents }}</a>
-        {%- if item.children and 'localtoc.html' not in sidebars -%}
-          {%- set children = item.children -%}
-        {%-
-          elif display_toc
-          and item.current
-          and theme_globaltoc_include_local|tobool
-          and 'localtoc.html' not in sidebars
-        %}
-          {%- set derendered_localtoc = derender_toc(toc, False) -%}
-          {%-
-            if derendered_localtoc|length == 1
-            and derendered_localtoc[0].href == "#"
-          -%}
-            {%- set children = derendered_localtoc[0].children -%}
-          {%- else -%}
-            {%- set children = derendered_localtoc -%}
-          {%- endif -%}
-        {%- endif -%}
-        {%- if children -%}
-          <ul>
-            {% for child in children recursive -%}
-              <li>
-                {% if child.caption %}
-                  <p class="menu-label">{{ child.caption }}</p>
-                {% endif %}
-                {% if child.href and child.contents %}
-                  <a href="{{ child.href|e }}">{{ child.contents }}</a>
-                {% elif child.contents %}
-                  <p>{{ child.contents }}</p>
-                {% endif %}
-                {%- if child.children -%}
-                <ul>
-                  {{ loop(child.children) }}
-                </ul>
-                {% endif %}
-              </li>
-            {% endfor %}
-          </ul>
-        {%- endif %}
-      </li>
-      {% if loop.last %}
-        </ul>
-      {% endif %}
-    {% endif %}
-  {%- endfor %}
-  </ul>
-</nav>
+    {%- endfor %}
+    </ul>
+  </nav>
 {% endif %}


### PR DESCRIPTION
This greatly simplifies globaltoc.html and corrects multiple behaviours.

**Before:**
Subpages did not reliably show up on RHS. This was predictable but extremely confusing and frustrating and incorrect.
![Screenshot from 2022-08-02 17-25-11](https://user-images.githubusercontent.com/28590748/182316978-25e08b77-5eb8-4562-a46d-91e58d206323.png)
![Screenshot from 2022-08-02 17-25-25](https://user-images.githubusercontent.com/28590748/182316805-934c84ad-8b5b-40df-bfae-4da251420054.png)

When the localtoc was included, subpages did show up, but so did other headings in the parent document, and the current subpage was not highlighted
![Screenshot from 2022-08-02 17-23-05](https://user-images.githubusercontent.com/28590748/182317161-4fb319b4-4576-43a4-af63-50f5f7c4a697.png)

**After**
Subpages are displayed, and the current subpage is highlighted
![Screenshot from 2022-08-02 17-24-54](https://user-images.githubusercontent.com/28590748/182317695-dd75734d-52e3-4c25-b852-f6caf21ecbc7.png)
![Screenshot from 2022-08-02 17-24-26](https://user-images.githubusercontent.com/28590748/182317671-ac0f925d-7915-4706-b7d1-e8b2ec54a7bf.png)

When localtoc is included, the current page is still highlighted, and parent subheadings are not erroneously included
![Screenshot from 2022-08-02 17-21-22](https://user-images.githubusercontent.com/28590748/182317801-d161ed62-6bdc-40cd-9516-6537e86ad545.png)

There is also less logic duplication and the logic is much more straightforward.

