### PR TITLE
Clearer figure captions

### DIFF
--- a/openff_sphinx_theme/openff_sphinx_theme/sass/material-content.scss
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/material-content.scss
@@ -446,6 +446,7 @@ figure {
   // Figure images
   img {
     display: block;
+    margin: 0 auto;
   }
 }
 
@@ -455,6 +456,7 @@ figcaption {
   text-align: justify;
   font-size: 90%;
   hyphens: auto;
+  width: 80%;
 }
 
 // Limit width to container


### PR DESCRIPTION
- Centers figure images by default
- Adds margin to figure captions to better distinguish them from main text