### PR TITLE
Attempt to change nav menu overflow behavior

### DIFF
--- a/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
+++ b/openff_sphinx_theme/openff_sphinx_theme/sass/site.sass
@@ -408,3 +408,12 @@ a:hover:not(.is-active)
 
 main > .columns
     max-width: 100vw
+
+.menu-list a
+    overflow-x: hidden
+    text-overflow: ellipsis
+    overflow-wrap: normal
+    transition: width 0.3s
+    &:hover
+        width: fit-content
+        min-width: 100%


### PR DESCRIPTION
Currently, links in the menu (and other places like autosummary tables) can introduce a line break in the middle of a word to prevent overflow. This PR changes this behavior to truncate the link and insert an ellipsis, and then expand the link on mouseover.

- [x] Truncate to ellipsis
- [ ] Expand on hover
- [ ] Autosummary tables